### PR TITLE
Add config option to disable update checks/warning

### DIFF
--- a/codex-rs/core/src/config.rs
+++ b/codex-rs/core/src/config.rs
@@ -123,6 +123,9 @@ pub struct Config {
     /// and turn completions when not focused.
     pub tui_notifications: Notifications,
 
+    /// Disable background update checks that populate the in-app upgrade banner.
+    pub tui_disable_update_check: bool,
+
     /// The directory that should be treated as the current working directory
     /// for the session. All relative paths inside the business-logic layer are
     /// resolved against this path.
@@ -1068,6 +1071,11 @@ impl Config {
                 .as_ref()
                 .map(|t| t.notifications.clone())
                 .unwrap_or_default(),
+            tui_disable_update_check: cfg
+                .tui
+                .as_ref()
+                .map(|t| t.disable_update_check)
+                .unwrap_or(false),
         };
         Ok(config)
     }
@@ -1809,6 +1817,7 @@ model_verbosity = "high"
                 active_profile: Some("o3".to_string()),
                 disable_paste_burst: false,
                 tui_notifications: Default::default(),
+                tui_disable_update_check: false,
             },
             o3_profile_config
         );
@@ -1868,6 +1877,7 @@ model_verbosity = "high"
             active_profile: Some("gpt3".to_string()),
             disable_paste_burst: false,
             tui_notifications: Default::default(),
+            tui_disable_update_check: false,
         };
 
         assert_eq!(expected_gpt3_profile_config, gpt3_profile_config);
@@ -1942,6 +1952,7 @@ model_verbosity = "high"
             active_profile: Some("zdr".to_string()),
             disable_paste_burst: false,
             tui_notifications: Default::default(),
+            tui_disable_update_check: false,
         };
 
         assert_eq!(expected_zdr_profile_config, zdr_profile_config);
@@ -2002,6 +2013,7 @@ model_verbosity = "high"
             active_profile: Some("gpt5".to_string()),
             disable_paste_burst: false,
             tui_notifications: Default::default(),
+            tui_disable_update_check: false,
         };
 
         assert_eq!(expected_gpt5_profile_config, gpt5_profile_config);
@@ -2114,6 +2126,8 @@ mod notifications_tests {
     #[derive(Deserialize, Debug, PartialEq)]
     struct TuiTomlTest {
         notifications: Notifications,
+        #[serde(default)]
+        disable_update_check: bool,
     }
 
     #[derive(Deserialize, Debug, PartialEq)]

--- a/codex-rs/core/src/config_types.rs
+++ b/codex-rs/core/src/config_types.rs
@@ -239,6 +239,11 @@ pub struct Tui {
     /// Defaults to `false`.
     #[serde(default)]
     pub notifications: Notifications,
+
+    /// Disable background version checks that power the in-TUI upgrade banner.
+    /// Defaults to `false`.
+    #[serde(default)]
+    pub disable_update_check: bool,
 }
 
 #[derive(Deserialize, Debug, Clone, PartialEq, Default)]

--- a/codex-rs/tui/src/updates.rs
+++ b/codex-rs/tui/src/updates.rs
@@ -14,6 +14,10 @@ use codex_core::default_client::create_client;
 use crate::version::CODEX_CLI_VERSION;
 
 pub fn get_upgrade_version(config: &Config) -> Option<String> {
+    if config.tui_disable_update_check {
+        return None;
+    }
+
     let version_file = version_filepath(config);
     let info = read_version_info(&version_file).ok();
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -594,6 +594,10 @@ notifications = true
 # You can optionally filter to specific notification types.
 # Available types are "agent-turn-complete" and "approval-requested".
 notifications = [ "agent-turn-complete", "approval-requested" ]
+
+# Suppress version checks and the corresponding upgrade banner.
+# Defaults to false.
+disable_update_check = true
 ```
 
 > [!NOTE]
@@ -642,6 +646,7 @@ notifications = [ "agent-turn-complete", "approval-requested" ]
 | `file_opener` | `vscode` \| `vscode-insiders` \| `windsurf` \| `cursor` \| `none` | URI scheme for clickable citations (default: `vscode`). |
 | `tui` | table | TUI‑specific options. |
 | `tui.notifications` | boolean \| array<string> | Enable desktop notifications in the tui (default: false). |
+| `tui.disable_update_check` | boolean | Skip Codex CLI update checks and hide the in-TUI banner (default: false). |
 | `hide_agent_reasoning` | boolean | Hide model reasoning events. |
 | `show_raw_agent_reasoning` | boolean | Show raw reasoning (when available). |
 | `model_reasoning_effort` | `minimal` \| `low` \| `medium` \| `high` | Responses API reasoning effort. |


### PR DESCRIPTION
## Summary
Adds a config option `tui_disable_update_check` to disable the update check on startup:
```
✨⬆️ Update available! [X] -> [Y].
[Instructions...]
```

This allows us to centrally manage versions across a larger org without confusion.

## Testing
- Added unit testing and followed contributor's guide for verification.
- Ran release build, verified that update warning is shown. Re-ran it with the new config option, verified that update option is not shown.